### PR TITLE
Add VS build preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,31 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "displayName": "Default",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "vs2022",
+            "displayName": "Visual Studio 2022 x64",
+            "generator": "Visual Studio 17 2022",
+            "binaryDir": "${sourceDir}/build",
+            "architecture": "x64"
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default"
+        },
+        {
+            "name": "vs2022",
+            "configurePreset": "vs2022"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ cmake -S . -B build
 cmake --build build
 ```
 
+### Building with Visual Studio
+
+On Windows you can generate a Visual Studio solution using the provided
+`CMakePresets.json` file:
+
+```bash
+cmake --preset vs2022
+cmake --build --preset vs2022
+```
+
+This produces `emgdevice.sln` in the `build` directory which can be opened
+directly in Visual Studio for further development or debugging.
+
 ### Running Tests
 
 Unit tests build alongside the main executable. After configuring the project,


### PR DESCRIPTION
## Summary
- add CMake preset for Visual Studio 2022
- document how to build the project with Visual Studio using the preset

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_684a928cb7288330be3da091748924bf