### PR TITLE
Improve dependency integration docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,26 @@ project(emgdevice LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Optional paths to ImGui and ImPlot headers. If left empty the build will
+# fall back to the copies placed under the `include` directory.
+set(IMGUI_DIR "" CACHE PATH "Path to ImGui headers")
+set(IMPLOT_DIR "" CACHE PATH "Path to ImPlot headers")
+
 file(GLOB SOURCES "src/*.cpp")
 
 add_executable(emgdevice ${SOURCES})
 
 target_include_directories(emgdevice PUBLIC include)
+if(IMGUI_DIR)
+    target_include_directories(emgdevice PUBLIC ${IMGUI_DIR})
+elseif(EXISTS "${CMAKE_SOURCE_DIR}/include/imgui")
+    target_include_directories(emgdevice PUBLIC ${CMAKE_SOURCE_DIR}/include/imgui)
+endif()
+if(IMPLOT_DIR)
+    target_include_directories(emgdevice PUBLIC ${IMPLOT_DIR})
+elseif(EXISTS "${CMAKE_SOURCE_DIR}/include/implot")
+    target_include_directories(emgdevice PUBLIC ${CMAKE_SOURCE_DIR}/include/implot)
+endif()
 
 enable_testing()
 add_executable(test_emgdevice
@@ -17,4 +32,14 @@ add_executable(test_emgdevice
     src/DataProcessor.cpp
 )
 target_include_directories(test_emgdevice PRIVATE include)
+if(IMGUI_DIR)
+    target_include_directories(test_emgdevice PRIVATE ${IMGUI_DIR})
+elseif(EXISTS "${CMAKE_SOURCE_DIR}/include/imgui")
+    target_include_directories(test_emgdevice PRIVATE ${CMAKE_SOURCE_DIR}/include/imgui)
+endif()
+if(IMPLOT_DIR)
+    target_include_directories(test_emgdevice PRIVATE ${IMPLOT_DIR})
+elseif(EXISTS "${CMAKE_SOURCE_DIR}/include/implot")
+    target_include_directories(test_emgdevice PRIVATE ${CMAKE_SOURCE_DIR}/include/implot)
+endif()
 add_test(NAME unit COMMAND test_emgdevice)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ git clone https://github.com/ocornut/imgui include/imgui
 git clone https://github.com/epezent/implot include/implot
 ```
 
+### Custom library locations
+
+If you already have ImGui or ImPlot installed elsewhere, pass their paths when
+running `cmake`:
+
+```bash
+cmake -S . -B build -DIMGUI_DIR=/path/to/imgui -DIMPLOT_DIR=/path/to/implot
+cmake --build build
+```
+
+The variables are optional—if omitted the build falls back to the copies placed
+under `include/`.
+
 With the libraries in place you can run the CMake commands shown above to build
 the GUI application. If the headers are missing the project will still compile
 using stub implementations, but no user interface will be shown.


### PR DESCRIPTION
## Summary
- allow specifying ImGui and ImPlot paths via `IMGUI_DIR` and `IMPLOT_DIR`
- document how to point CMake at custom dependency locations

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_684af309aa0c8330adf0d11dc2c424e1